### PR TITLE
Add security section, fixed respec issue, changed affiliation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
         name: "Yoav Weiss",
         url: "https://blog.yoav.ws/",
         mailto: "yoav@yoav.ws",
-        company: "Akamai",
-        companyURL: "https://akamai.com/"
+        company: "Google",
+        companyURL: "https://google.com",
       }
         // Add additional editors here.
         // https://github.com/w3c/respec/wiki/editors
@@ -34,7 +34,8 @@
       "shortName": "priority-hints",
       "specStatus": "CG-DRAFT",
       "subjectPrefix": "[priority-hints]",
-      "wg": "WICG",
+      "wg": "Web Incubator Community Group",
+      "wgURI": "https://wicg.io",
       "otherLinks": [{
         "key": "Repository",
         "data": [{
@@ -504,6 +505,34 @@ Link: &lt;/app/script.js&gt;; importance=low</pre>
       scripts (e.g with
       <code>async</code>,
       <code>defer</code>) but a site could fix any misguesses across the board by being explicit using Priority Hints.</p>
+  </section>
+
+  <section>
+    <h2>Security and Privacy Considerations</h2>
+    <h3>Fingerprintability</h3>
+    <p>This specification does not expose any new information about the user and their preferences, so does not increase the risk of user fingerprinting.
+    At the same time, it does expose priority information to web servers that enables them to distinguish between browsers that support the feature and ones that do not support it.
+    This is not dissimilar to other web platform features, but with one important distinction: 
+    this information is exposed at the HTTP layer, allowing the server implementation to discover discrepancies between the User-Agent string the request is sent with and the browser that sent the request. 
+    It is not clear that this is a significant issue, but it is something for implementing user agents (and user agents which try to spoof others) to be aware of.
+    </p>
+    <h3>Negative ecosystem side-effects</h3>
+    <p>
+    There's a risk that monetizing third-party components, and ad networks in particular, will require publishers to use the feature in order to upgrade the priority of their resource requests.
+    While they certainly can do that, and enforce such a requirement by inspecting the HTTP/2 priorities of the resource requests they receive, the risk for that is rather small.
+    <ul>
+        <li><p>Such "priority upgrade" is already available in the platform today, e.g. when switching scripts from blocking to deferred or async ones.
+            There's no existing evidence that advertisers have required such hacks in order to make sure their resources load first.</p></li>
+        <li><p>Furthermore, monitoring that publishers complied with that requirement can be difficult for advertisers that run outside of the main frame, as it will require coordination between the their HTTP/2 termination point and the application layer.
+            Depending on their architecture, such coordination may not be trivial.</p></li>
+    </ul>
+
+    </p>
+
+    <p>If such a problem arise in the future, browsers will be able to find creative ways to fight against it.
+    For example, since Priority Hints are hints by their nature, browsers will be able to ignore those hints for third-party hosts that are known to abuse the feature.
+    In such a case, advertisers will not be able to distinguish such user agent intervention from lack of compliance with their Priority Hints requirements.
+    </p>    
   </section>
 
   <section data-dfn-for="references">

--- a/index.html
+++ b/index.html
@@ -515,6 +515,7 @@ Link: &lt;/app/script.js&gt;; importance=low</pre>
     This is not dissimilar to other web platform features, but with one important distinction: 
     this information is exposed at the HTTP layer, allowing the server implementation to discover discrepancies between the User-Agent string the request is sent with and the browser that sent the request. 
     It is not clear that this is a significant issue, but it is something for implementing user agents (and user agents which try to spoof others) to be aware of.
+    It is also possible that the network patterns that result from the use of the feature would be observable to passive network-based observers and will enable them to distinguish supporting and non-supporting browsers.
     </p>
     <h3>Negative ecosystem side-effects</h3>
     <p>

--- a/index.html
+++ b/index.html
@@ -521,7 +521,7 @@ Link: &lt;/app/script.js&gt;; importance=low</pre>
     There's a risk that monetizing third-party components, and ad networks in particular, will require publishers to use the feature in order to upgrade the priority of their resource requests.
     While they certainly can do that, and enforce such a requirement by inspecting the HTTP/2 priorities of the resource requests they receive, the risk for that is rather small.
     <ul>
-        <li><p>Such "priority upgrade" is already available in the platform today, e.g. when switching scripts from blocking to deferred or async ones.
+        <li><p>Such "priority upgrade" is already available in the platform today, e.g., when switching scripts from blocking to deferred or async ones.
             There's no existing evidence that advertisers have required such hacks in order to make sure their resources load first.</p></li>
         <li><p>Furthermore, monitoring that publishers complied with that requirement can be difficult for advertisers that run outside of the main frame, as it will require coordination between the their HTTP/2 termination point and the application layer.
             Depending on their architecture, such coordination may not be trivial.</p></li>


### PR DESCRIPTION
This PR addresses mostly the lack of security/privacy considerations section, as pointed out in the [TAG review](https://github.com/w3ctag/design-reviews/issues/241#issuecomment-434604343)

It addresses Fingerprintability as well as abusive use by ad networks. On top of that, while I was there, I also fixed a couple of admin stuff such as affiliation and things respec was complaining about.  