### PR TITLE
Add extensible priority urgency effect

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -217,17 +217,36 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       between Priority Hints and request prioritization. However, it does describe ways in which implementations are encouraged to
       influence a request's overall fetch priority given a Priority Hint.</p>
 
+    <strong>HTTP Stream Priority</strong>
+    <p>
+    <p>Implementations are encouraged to use Priority Hints to influence the
+      <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-priority.html#name-urgency">stream urgency</a> assigned to
+      a given request when
+      <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-priority.html">HTTP extensible prioritization</a> is
+      being used at the transport layer (for example, with HTTP/3).
+      It is not the intention of the different <code>importance</code> states to directly map to existing browser priority values,
+      but instead act as a relative influencer among requests of a similar type.</p>
+    </p>
+    <div class="example">
+      <p>
+        If requests for <code>image</code>
+        <a data-lt="destination">destinations</a> in a particular implementation are typically assigned a stream urgency of
+        <code>3</code>, a request for an image with <code>importance="high"</code> might be assigned a stream urgency less than
+        <code>3</code> (where lower values are higher priority).</p>
+    </div>
+
     <strong>HTTP/2 Relative Stream Priority</strong>
-    <p>Implementations are encouraged to use Priority Hints to influence the HTTP/2 stream priority assigned to a given request.
+    <p>Implementations are encouraged to use Priority Hints to influence the HTTP/2 stream priority assigned to a given request
+      when <a href="https://httpwg.org/http2-spec/draft-ietf-httpbis-http2bis.html#name-prioritization">HTTP/2 prioritization</a>
+      is being used at the transport layer.
       It is not the intention of the different <code>importance</code> states to directly map to existing browser priority values,
       but instead act as a relative influencer among requests of a similar type.</p>
     <div class="example">
       <p>
         If requests for <code>image</code>
         <a data-lt="destination">destinations</a> in a particular implementation are typically assigned a stream weight of
-        <code>60</code>, a request for an image with <code>importance="low"</code> might be assigned a stream weight less than
-        <code>60</code>. In other words, <code>importance="low"</code> on an image might lead to an entirely different resolved
-        HTTP/2 stream priority than <code>importance="low"</code> on something like a script, or an iframe.
+        <code>60</code>, a request for an image with <code>importance="high"</code> might be assigned a stream weight higher than
+        <code>60</code>.
       </p>
     </div>
 


### PR DESCRIPTION
Added some text explaining the effect priority-hints would have on HTTP extensible priorities (the scheme used for HTTP/3).

Fix #50