### PR TITLE
Added language to caution against over-use.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -18,6 +18,12 @@ provide developers with the control to indicate a resource's
 relative importance to the browser for the browser to use when making
 loading prioritization decisions.
 
+It is important to note that changing the importance of one resource usually
+comes at the cost of another resource so hints should be applied sparingly.
+Marking everything in the document as important will likely make for a worse
+user experience but correctly tagging a few resources that the browser would
+otherwise not load optimally can have a huge benefit.
+
 ### Adoption path
 Markup based signal should be added in a way such that non-supporting
 browsers will simply ignore them and load all resources, potentially not

--- a/index.bs
+++ b/index.bs
@@ -82,6 +82,11 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       the request's overall priority in ways described in the <a href="#effects-of-priority-hints">Effects of Priority Hints</a> section.
     </p>
 
+    <p>It is important to note that changing the importance of one resource usually comes at the cost of another resource so
+    hints should be applied sparingly. Marking everything in the document as important will likely make for a worse user experience
+    but correctly tagging a few resources that the browser would otherwise not load optimally can have a huge benefit.
+    </p>
+
   </section>
 
   <section>


### PR DESCRIPTION
Added a paragraph to the introduction to make it clear that just spraying ```importance=high``` across everything will result in worse performance and that hints should be used sparingly.

See #55