### PR TITLE
Added remaining processing models

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,6 +21,11 @@ urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type:element; text:link
     type:element; text:script
     type: dfn; url: #the-link-element; text: link element;
+    type: dfn; url: #fetching-resources; text: Fetching resources;
+    type: dfn; url: #fetch-and-process-the-linked-resource; text: fetching and processing the linked resource;
+    type: dfn; url: #external-resource-link; text: external resource links;
+    type: dfn; url: #create-a-link-element-request; text: create a link element request;
+    type: dfn; url: #fetching-and-processing-a-resource-from-a-link-element; text: Fetching and processing a resource from a link element;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     type: dfn; url: #concept-request; text: fetch request;
     type: dfn; url: #concept-request; text: request;
@@ -77,10 +82,10 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       in order to avoid bandwidth contention of these resources with more critical ones.</p>
 
     <p>Currently web developers have very little control over the heuristic importance of loaded resources, other than speeding
-      up their discovery using <code>&lt;link rel=preload&gt;</code>([[PRELOAD]]). Browsers mostly determine a request's priority based on the
+      up their discovery using <code>&lt;link rel=preload&gt;</code>([[PRELOAD|Preload]]). Browsers mostly determine a request's priority based on the
       request's <a>destination</a>, and location in the containing document if applicable.</p>
 
-    <p>This document details use cases and modifications to [[FETCH]] and [[HTML]] markup that will provide developers
+    <p>This document details use cases and modifications to [[FETCH|Fetch]] and [[HTML|HTML]] markup that will provide developers
       control to indicate a resource's relative importance to the browser, enabling the browser to act on those indications to influence
       the request's overall priority in ways described in the <a href="#effects-of-priority-hints">Effects of Priority Hints</a> section.
     </p>
@@ -160,7 +165,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     </table>
 
     <h3 id="fetch-integration">Fetch Integration</h3>
-    <em>This section will be removed once the [[FETCH]] specification has been modified.</em>
+    <em>This section will be removed once the [[FETCH|Fetch]] specification has been modified.</em>
     <ol>
       <li>
         <p>We extend the [=request=] definition:</p>
@@ -206,7 +211,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     </ol>
 
     <h3 id="html-integration">HTML Integration</h3>
-    <em>This section will be removed once the [[HTML]] specification has been modified.</em>
+    <em>This section will be removed once the [[HTML|HTML]] specification has been modified.</em>
     <p>For the supported elements (<{img}>, <{link}>, <{script}> and <{iframe}>) the integration
     with HTML is to add an <code data-x="">importance</code> attribute to the relevant element
     specification and pass the value through to the underlying fetch for the resource referenced
@@ -215,6 +220,19 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     no downstream impact on later behaviors of the given element (i.e. later fetches initiated by
     a frame or script are not impacted nor is the scheduling of execution or prioritization of
     tasks affected).</p>
+
+    <ol>
+    <li><p>We extend the [=Fetching resources=] process with an additional section:</p>
+      <p>Importance attributes</p>
+      <p>An <dfn export>importance attribute</dfn> is an <span>enumerated attribute</span>.  Each
+        [=importance enum|Fetch importance enum=] is a keyword for this attribute, mapping
+        to a state of the same name.</p>
+      <p>The attribute's <i data-x="missing value default">missing value default</i> and <i
+        data-x="invalid value default">invalid value default</i> are both the [=auto=] state.</p>
+      <p>The impact of these states on the processing model of various [=fetch|fetches=] is defined
+      in more detail throughout this specification, in [[FETCH|Fetch]], and in
+      [[PRIORITY-HINTS|Priority Hints]].</p>
+    </ol>
 
     <h4 id="img">img</h4>
     <ol>
@@ -237,17 +255,24 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     <h4 id="link">link</h4>
     <ol>
       <li><p>We add to the [=link element=] content attributes:</p>
-        <p><code data-x="">importance</code> - Importance for
-          <span data-x="concept-fetch">fetches</span> initiated by the element
+        <p><code data-x="">importance</code> - Importance for [=fetch|fetches=] initiated by the
+          element.
         </p>
+      <li><p>We add to the [=link element=] content attribute descriptions:</p>
+        <p>The <dfn element-attr for="link"><code data-x="attr-link-importance">importance</code>
+          </dfn> attribute is an [=importance attribute=]. It is intended for use with
+          [=external resource links=], where it helps set the [=importance=] used when
+          [=fetching and processing the linked resource=].</p>
       <li>We extend the <{link}> element as follows:
         <pre class="idl">
         partial interface HTMLLinkElement {
             [CEReactions] attribute DOMString importance;
         };
         </pre>
-      <li>TODO: Complete documenting the various points in the link processing model to pass the
-        importance through to the fetch for the referenced link resource.
+      <li><p>We extend [=create a link element request=] of [=Fetching and processing a resource
+        from a link element=] by adding a step before returning the request:</p>
+        <p>Set <var>request</var>'s {{Request/importance}} to the current state of <var ignore=''>
+        el</var>'s <code data-x="attr-link-importance">importance</code> content attribute.</p>
     </ol>
 
     <h4 id="script">script</h4>
@@ -453,7 +478,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       </xmp>
     </div>
 
-    <p>As above examples illustrate, importance can be specified via declarative markup, Link HTTP header ([[RFC5988]]), 
+    <p>As above examples illustrate, importance can be specified via declarative markup, Link HTTP header ([[RFC5988|RFC5988]]), 
       or scheduled via JavaScript.</p>
 
     <h2 id="adoptionpath">Adoption path</h2>

--- a/index.bs
+++ b/index.bs
@@ -14,38 +14,46 @@ Default Highlight: js
 </pre>
 
 <pre class=anchors>
-urlPrefix: https://html.spec.whatwg.org; spec: HTML;
-    type:dfn; for:/; text:enumerated attribute
-    type:dfn; for:/; text:invalid value default
-    type:dfn; for:/; text:missing value default
-    type:element; text:link
-    type:element; text:script
-    type:element; text:img
-    type:element; text:iframe
-    type: dfn; url: #elements-3; text: List of elements;
-    type: dfn; url: #the-link-element; text: link element;
-    type: dfn; url: #the-img-element; text: img element;
-    type: dfn; url: #the-script-element; text: script element;
-    type: dfn; url: #the-iframe-element; text: iframe element;
-    type: dfn; url: #link-type-modulepreload; text: modulepreload;
+urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
+    type:dfn; for:/; text: enumerated attribute
+    type:dfn; for:/; text: invalid value default
+    type:dfn; for:/; text: missing value default
+urlPrefix: https://html.spec.whatwg.org/multipage/urls-and-fetching.html; spec: HTML;
     type: dfn; url: #fetching-resources; text: Fetching resources;
-    type: dfn; url: #reacting-to-dom-mutations; text: Reacting to DOM mutations;
+urlPrefix: https://html.spec.whatwg.org/multipage/images.html; spec: HTML;
     type: dfn; url: #update-the-image-data; text: update the image data;
     type: dfn; url: #reacting-to-environment-changes; text: Reacting to environment changes;
+urlPrefix: https://html.spec.whatwg.org/multipage/embedded-content.html; spec: HTML;
+    type: element; url: #the-img-element; text: img
+    type: dfn; url: #the-img-element; text: img element;
+urlPrefix: https://html.spec.whatwg.org/multipage/links.html; spec: HTML;
+    type: dfn; url: #external-resource-link; text: external resource links;
+    type: dfn; url: #link-type-modulepreload; text: modulepreload;
+urlPrefix: https://html.spec.whatwg.org/multipage/semantics.html; spec: HTML;
+    type: element; url: #the-link-element; text:link
+    type: dfn; url: #the-link-element; text: link element;
+    type: dfn; url: #create-a-link-element-request; text: create a link element request;
     type: dfn; url: #fetch-and-process-the-linked-resource; text: fetching and processing the linked resource;
     type: dfn; url: #fetch-and-process-the-linked-resource; text: fetch and process the linked resource;
-    type: dfn; url: #external-resource-link; text: external resource links;
-    type: dfn; url: #create-a-link-element-request; text: create a link element request;
     type: dfn; url: #fetching-and-processing-a-resource-from-a-link-element; text: Fetching and processing a resource from a link element;
-    type: dfn; url: #shared-attribute-processing-steps-for-iframe-and-frame-elements; text: shared attribute processing steps for iframe and frame elements;
-    type: dfn; url: #process-the-iframe-attributes; text: processing the iframe attributes;
+urlPrefix: https://html.spec.whatwg.org/multipage/scripting.html; spec: HTML;
+    type: element; text:script
+    type: dfn; url: #the-script-element; text: script element;
     type: dfn; url: #the-script-element:data-block-2; text: data blocks;
+    type: dfn; url: #:~:text=dynamically%20has%20no%20direct%20effect; text: direct effect when changed dynamically;
+    type: dfn; url: #prepare-a-script; text: prepare a script;
+urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; spec: HTML;
     type: dfn; url: #script-fetch-options; text: Script fetch options;
+    type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
     type: dfn; url: #default-classic-script-fetch-options; text: default classic script fetch options;
     type: dfn; url: #set-up-the-classic-script-request; text: set up the classic script request;
-    type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
-    type: dfn; url: #prepare-a-script; text: prepare a script;
-    type: dfn; url: #:~:text=dynamically%20has%20no%20direct%20effect; text: direct effect when changed dynamically;
+urlPrefix: https://html.spec.whatwg.org/multipage/iframe-embed-object.html; spec: HTML;
+    type: element; url: #the-iframe-element; text:iframe
+    type: dfn; url: #the-iframe-element; text: iframe element;
+    type: dfn; url: #process-the-iframe-attributes; text: processing the iframe attributes;
+    type: dfn; url: #shared-attribute-processing-steps-for-iframe-and-frame-elements; text: shared attribute processing steps for iframe and frame elements;
+urlPrefix: https://html.spec.whatwg.org/multipage/indices.html; spec: HTML;
+    type: dfn; url: #elements-3; text: List of elements;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     type: dfn; url: #concept-request; text: fetch request;
     type: dfn; url: #concept-request; text: request;

--- a/index.bs
+++ b/index.bs
@@ -14,7 +14,7 @@ Default Highlight: js
 </pre>
 
 <pre class=anchors>
-urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
+urlPrefix: https://html.spec.whatwg.org; spec: HTML;
     type:dfn; for:/; text:enumerated attribute
     type:dfn; for:/; text:invalid value default
     type:dfn; for:/; text:missing value default
@@ -39,12 +39,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type: dfn; url: #fetching-and-processing-a-resource-from-a-link-element; text: Fetching and processing a resource from a link element;
     type: dfn; url: #shared-attribute-processing-steps-for-iframe-and-frame-elements; text: shared attribute processing steps for iframe and frame elements;
     type: dfn; url: #process-the-iframe-attributes; text: processing the iframe attributes;
-    type: dfn; url: #data-block; text: data blocks;
+    type: dfn; url: #the-script-element:data-block-2; text: data blocks;
     type: dfn; url: #script-fetch-options; text: Script fetch options;
     type: dfn; url: #default-classic-script-fetch-options; text: default classic script fetch options;
     type: dfn; url: #set-up-the-classic-script-request; text: set up the classic script request;
     type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
     type: dfn; url: #prepare-a-script; text: prepare a script;
+    type: dfn; url: #:~:text=dynamically%20has%20no%20direct%20effect; text: direct effect when changed dynamically;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     type: dfn; url: #concept-request; text: fetch request;
     type: dfn; url: #concept-request; text: request;
@@ -342,7 +343,8 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
             <span>reflect</span> the <code data-x="attr-script-importance">importance</code>
             content attribute, <span>limited to only known values</span>.
           <li>We add <code data-x="attr-script-importance">importance</code> to the list of
-            attributes that have no direct effect when changed dynamically.
+            attributes that have no [=direct effect when changed dynamically=] (For browsers that
+            don't support text linking, search for "dynamically has no direct effect").
         </ol>
       <li>We modify the list of attributes not to be specified when used in [=data blocks=] to
         include the <code data-x="attr-script-importance">importance</code> attribute.

--- a/index.bs
+++ b/index.bs
@@ -44,6 +44,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type: dfn; url: #default-classic-script-fetch-options; text: default classic script fetch options;
     type: dfn; url: #set-up-the-classic-script-request; text: set up the classic script request;
     type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
+    type: dfn; url: #prepare-a-script; text: prepare a script;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     type: dfn; url: #concept-request; text: fetch request;
     type: dfn; url: #concept-request; text: request;
@@ -272,9 +273,6 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
           data-x="dom-img-importance">importance</code></dfn> IDL attribute must
           <span>reflect</span> the <code data-x="attr-img-importance">importance</code>
           content attribute, <span>limited to only known values</span>.</p>
-      <li><p>We add to [=Reacting to DOM mutations=]:</p>
-        <p>The element's <code data-x="attr-img-importance">importance</code> attribute's state is
-          changed.</p>
       <li><p>We add a step to [=update the image data|Updating the image data=] before fetching the
           image:</p>
         <p>Set <var>request</var>'s {{Request/importance}} to the current state of the element's
@@ -334,7 +332,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
             [CEReactions] attribute DOMString <span data-x="dom-script-importance">importance</script>;
         };
         </pre>
-      <li><p>We add to the <{img}> element content attribute descriptions:</p>
+      <li><p>We add to the <{script}> element content attribute descriptions:</p>
         <ol>
           <li>The <dfn element-attr for="script"><code data-x="attr-script-importance">importance
             </code></dfn> attribute is an [=importance attribute=]. Its purpose is to set the
@@ -357,6 +355,12 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       <li>We extend [=set up the classic script request=] to set <var>request</var>'s
         {{Request/importance}} to <var>option</var>'s
         <code data-x="concept-script-fetch-options-importance">importance</code>
+      <li><p>We insert a step before step 24 of [=prepare a script=]:</p>
+        <p>Let <var>importance</var> be the current state of the element's <code
+          data-x="attr-script-importance">importance</code> attribute.</p>
+      <li><p>We modify step 24 of [=prepare a script=] to include:</p>
+        <p><code data-x="concept-script-fetch-options-importance">importance</code> is
+        <var>importance</var>.</p>
       <li>We extend [=set up the module script request=] to set <var>request</var>'s
         {{Request/importance}} to <var>option</var>'s
         <code data-x="concept-script-fetch-options-importance">importance</code>
@@ -385,7 +389,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
           data-x="dom-iframe-importance">importance</code></dfn> IDL attribute must
           <span>reflect</span> the <code data-x="attr-iframe-importance">importance</code>
           content attribute, <span>limited to only known values</span>.</p>
-      <li><p>We modify the resource creation step of
+      <li><p>We modify step 5 (the resource creation step) of
           [=shared attribute processing steps for iframe and frame elements=] to include:</p>
         <p>...and whose {{Request/importance}} is the current state of element's
           <code data-x="attr-iframe-importance">importance</code> content attribute</p>

--- a/index.bs
+++ b/index.bs
@@ -20,12 +20,30 @@ urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type:dfn; for:/; text:missing value default
     type:element; text:link
     type:element; text:script
+    type:element; text:img
+    type:element; text:iframe
+    type: dfn; url: #elements-3; text: List of elements;
     type: dfn; url: #the-link-element; text: link element;
+    type: dfn; url: #the-img-element; text: img element;
+    type: dfn; url: #the-script-element; text: script element;
+    type: dfn; url: #the-iframe-element; text: iframe element;
+    type: dfn; url: #link-type-modulepreload; text: modulepreload;
     type: dfn; url: #fetching-resources; text: Fetching resources;
+    type: dfn; url: #reacting-to-dom-mutations; text: Reacting to DOM mutations;
+    type: dfn; url: #update-the-image-data; text: update the image data;
+    type: dfn; url: #reacting-to-environment-changes; text: Reacting to environment changes;
     type: dfn; url: #fetch-and-process-the-linked-resource; text: fetching and processing the linked resource;
+    type: dfn; url: #fetch-and-process-the-linked-resource; text: fetch and process the linked resource;
     type: dfn; url: #external-resource-link; text: external resource links;
     type: dfn; url: #create-a-link-element-request; text: create a link element request;
     type: dfn; url: #fetching-and-processing-a-resource-from-a-link-element; text: Fetching and processing a resource from a link element;
+    type: dfn; url: #shared-attribute-processing-steps-for-iframe-and-frame-elements; text: shared attribute processing steps for iframe and frame elements;
+    type: dfn; url: #process-the-iframe-attributes; text: processing the iframe attributes;
+    type: dfn; url: #data-block; text: data blocks;
+    type: dfn; url: #script-fetch-options; text: Script fetch options;
+    type: dfn; url: #default-classic-script-fetch-options; text: default classic script fetch options;
+    type: dfn; url: #set-up-the-classic-script-request; text: set up the classic script request;
+    type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     type: dfn; url: #concept-request; text: fetch request;
     type: dfn; url: #concept-request; text: request;
@@ -236,14 +254,37 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
     <h4 id="img">img</h4>
     <ol>
-    <li>We extend the <{img}> element as follows:
-      <pre class="idl">
-      partial interface HTMLImageElement {
-          [CEReactions] attribute DOMString importance;
-      };
-      </pre>
-    <li>TODO: Complete documenting the various points in the image processing model to pass the
-      importance through to the fetch for the given image.
+      <li><p>We add to the <{img}> element content attributes:</p>
+        <p><code data-x="">importance</code> - Importance for [=fetch|fetches=] initiated by the
+          element.
+        </p>
+      <li>We extend the <{img}> element DOM interface as follows:
+        <pre class="idl">
+        partial interface HTMLImageElement {
+            [CEReactions] attribute DOMString <span data-x="dom-img-importance">importance</span>;
+        };
+        </pre>
+      <li><p>We add to the <{img}> element content attribute descriptions:</p>
+        <p>The <dfn element-attr for="img"><code data-x="attr-img-importance">importance</code>
+          </dfn> attribute is an [=importance attribute=]. Its purpose is to set the [=importance=]
+          used when [=fetching=] the image.</p>
+        <p>The <dfn attribute for="HTMLImageElement"><code
+          data-x="dom-img-importance">importance</code></dfn> IDL attribute must
+          <span>reflect</span> the <code data-x="attr-img-importance">importance</code>
+          content attribute, <span>limited to only known values</span>.</p>
+      <li><p>We add to [=Reacting to DOM mutations=]:</p>
+        <p>The element's <code data-x="attr-img-importance">importance</code> attribute's state is
+          changed.</p>
+      <li><p>We add a step to [=update the image data|Updating the image data=] before fetching the
+          image:</p>
+        <p>Set <var>request</var>'s {{Request/importance}} to the current state of the element's
+          <code data-x="attr-img-importance">importance</code> attribute.</p>
+      <li><p>We add a step to [=Reacting to environment changes=] when setting the image request's
+          image data, before the request is fetched:</p>
+        <p>Set <var>request</var>'s {{Request/importance}} to the current state of the element's
+          <code data-x="attr-img-importance">importance</code> attribute.</p>
+      <li>We modify the [=List of elements=] to include the 
+        <span data-x="attr-img-importance">importance</span> attribute on the <{img}> element.
     </ol>
 
     <h4 id="picture">picture</h4>
@@ -273,30 +314,84 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
         from a link element=] by adding a step before returning the request:</p>
         <p>Set <var>request</var>'s {{Request/importance}} to the current state of <var ignore=''>
         el</var>'s <code data-x="attr-link-importance">importance</code> content attribute.</p>
+      <li><p>We extend the [=fetch and process the linked resource=] algorithm of [=modulepreload=]
+        links by adding a step before setting the render-blocking state:</p>
+        <p>Let {{Request/importance}} be the current state of the element's
+        <code data-x="attr-link-importance">importance</code> attribute.</p>
+      <li>We modify the [=List of elements=] to include the 
+        <span data-x="attr-link-importance">importance</span> attribute on the <{link}> element.
     </ol>
 
     <h4 id="script">script</h4>
     <ol>
-      <li>We extend the <{script}> element as follows:
+      <li><p>We add to the <{script}> element content attributes:</p>
+        <p><code data-x="">importance</code> - Importance for [=fetch|fetches=] initiated by the
+          element.
+        </p>
+      <li>We extend the <{script}> element DOM interface as follows:
         <pre class="idl">
         partial interface HTMLScriptElement {
-            [CEReactions] attribute DOMString importance;
+            [CEReactions] attribute DOMString <span data-x="dom-script-importance">importance</script>;
         };
         </pre>
-      <li>TODO: Complete documenting the various points in the script processing model to pass the
-        importance through to the fetch for the referenced script resource.
+      <li><p>We add to the <{img}> element content attribute descriptions:</p>
+        <ol>
+          <li>The <dfn element-attr for="script"><code data-x="attr-script-importance">importance
+            </code></dfn> attribute is an [=importance attribute=]. Its purpose is to set the
+            [=importance=] used when [=fetching=] the script.
+          <li>The <dfn attribute for="HTMLScriptElement"><code
+            data-x="dom-script-importance">importance</code></dfn> IDL attribute must
+            <span>reflect</span> the <code data-x="attr-script-importance">importance</code>
+            content attribute, <span>limited to only known values</span>.
+          <li>We add <code data-x="attr-script-importance">importance</code> to the list of
+            attributes that have no direct effect when changed dynamically.
+        </ol>
+      <li>We modify the list of attributes not to be specified when used in [=data blocks=] to
+        include the <code data-x="attr-script-importance">importance</code> attribute.
+      <li><p>We extend the [=Script fetch options=] struct:<p>
+        <p><span data-x="concept-script-fetch-options-importance">importance</span> - The
+          {{Request/importance}} for the initial [=fetch=].</p>
+      <li>We extend [=default classic script fetch options=] to include "<code>auto</code>"
+        as the default value for <code data-x="concept-script-fetch-options-importance">
+        importance</code>.
+      <li>We extend [=set up the classic script request=] to set <var>request</var>'s
+        {{Request/importance}} to <var>option</var>'s
+        <code data-x="concept-script-fetch-options-importance">importance</code>
+      <li>We extend [=set up the module script request=] to set <var>request</var>'s
+        {{Request/importance}} to <var>option</var>'s
+        <code data-x="concept-script-fetch-options-importance">importance</code>
+      <li>We modify the [=List of elements=] to include the 
+        <span data-x="attr-script-importance">importance</span> attribute on the <{script}>
+        element.
     </ol>
 
     <h4 id="iframe">iframe</h4>
     <ol>
-      <li>We extend the <{iframe}> element as follows:
+      <li><p>We add to the <{iframe}> element content attributes:</p>
+        <p><code data-x="">importance</code> - Importance for [=fetch|fetches=] initiated by the
+          element.
+        </p>
+      <li>We extend the <{iframe}> element DOM interface as follows:
         <pre class="idl">
         partial interface HTMLIFrameElement {
-            [CEReactions] attribute DOMString importance;
+            [CEReactions] attribute DOMString <span data-x="dom-iframe-importance">importance</span>;
         };
         </pre>
-      <li>TODO: Complete documenting the various points in the iframe processing model to pass the
-        importance through to the fetch for the referenced iframe resource.
+      <li><p>We add to the <{iframe}> content attribute descriptions:</p>
+        <p>The <dfn element-attr for="iframe"><code data-x="attr-iframe-importance">importance
+          </code></dfn> attribute is an [=importance attribute=]. Its purpose is to set the
+          [=importance=] used when [=processing the iframe attributes=].</p>
+        <p>The <dfn attribute for="HTMLIFrameElement"><code
+          data-x="dom-iframe-importance">importance</code></dfn> IDL attribute must
+          <span>reflect</span> the <code data-x="attr-iframe-importance">importance</code>
+          content attribute, <span>limited to only known values</span>.</p>
+      <li><p>We modify the resource creation step of
+          [=shared attribute processing steps for iframe and frame elements=] to include:</p>
+        <p>...and whose {{Request/importance}} is the current state of element's
+          <code data-x="attr-iframe-importance">importance</code> content attribute</p>
+      <li>We modify the [=List of elements=] to include the 
+        <span data-x="attr-iframe-importance">importance</span> attribute on the <{iframe}>
+        element.
     </ol>
 
     <h2 id="effects-of-priority-hints">Effects of Priority Hints</h2>


### PR DESCRIPTION
Added the steps for HTML integration with the remaining tags, based on the steps used for refererpolicy (where appripriate).

This included the base integration with the HTML "Fetching Resources" section.