### PR TITLE
Remove fetchpriority from iFrames

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -38,7 +38,7 @@ Priority Hints addresses the above use-cases using the following concepts:
 
 * A `fetchpriority` attribute to signal to the browser the relative priority of a resource.
 
-* The `fetchpriority` attribute may be used with elements including link, img, script and iframe. This keyword hints to the browser the relative fetch priority a developer intends for a resource to have. Consider it an upgrade/downgrade mechanism for hinting at resource priority.
+* The `fetchpriority` attribute may be used with elements including link, img and script. This keyword hints to the browser the relative fetch priority a developer intends for a resource to have. Consider it an upgrade/downgrade mechanism for hinting at resource priority.
 
 * The `fetchpriority` attribute will has three states that will influence the current browser priorities:
 

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -40,7 +40,7 @@ Priority Hints addresses the above use-cases using the following concepts:
 
 * The `fetchpriority` attribute may be used with elements including link, img and script. This keyword hints to the browser the relative fetch priority a developer intends for a resource to have. Consider it an upgrade/downgrade mechanism for hinting at resource priority.
 
-* The `fetchpriority` attribute will has three states that will influence the current browser priorities:
+* The `fetchpriority` attribute has three states that will influence the current browser priorities:
 
   * `high` - The developer considers the resource as being important relative to the default priority for resources of the same type.
   * `low` - The developer considers the resource as being less important relative to the default priority for resources of the same type.

--- a/index.bs
+++ b/index.bs
@@ -68,6 +68,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
 <body>
   <section>
+    <h2 id="summary">Summary</h2>
     <p>
       This specification describes a browser API enabling developers to signal the priority of each resource they need to download.
       It introduces the
@@ -77,6 +78,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     </p>
   </section>
   <section id="sotd">
+    <h2 id="unofficial">Unofficial</h2>
     <p>
       This is an unofficial proposal.
     </p>

--- a/index.bs
+++ b/index.bs
@@ -47,11 +47,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; spec: HTML;
     type: dfn; url: #set-up-the-module-script-request; text: set up the module script request;
     type: dfn; url: #default-classic-script-fetch-options; text: default classic script fetch options;
     type: dfn; url: #set-up-the-classic-script-request; text: set up the classic script request;
-urlPrefix: https://html.spec.whatwg.org/multipage/iframe-embed-object.html; spec: HTML;
-    type: element; url: #the-iframe-element; text:iframe
-    type: dfn; url: #the-iframe-element; text: iframe element;
-    type: dfn; url: #process-the-iframe-attributes; text: processing the iframe attributes;
-    type: dfn; url: #shared-attribute-processing-steps-for-iframe-and-frame-elements; text: shared attribute processing steps for iframe and frame elements;
 urlPrefix: https://html.spec.whatwg.org/multipage/indices.html; spec: HTML;
     type: dfn; url: #elements-3; text: List of elements;
 urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
@@ -77,7 +72,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
       This specification describes a browser API enabling developers to signal the priority of each resource they need to download.
       It introduces the
       <a href="#solution">fetchpriority</a> <a data-lt="enumerated attribute">attribute</a> that may be used with <code>HTML</code> elements such as
-      <{img}>, <{link}>, <{script}> and <{iframe}> and the {{RequestInit/priority}} <a data-lt="enumerated attribute">attribute</a>
+      <{img}>, <{link}>, and <{script}> as well as the {{RequestInit/priority}} <a data-lt="enumerated attribute">attribute</a>
       on the {{Request|RequestInit}} of [[fetch#fetch-method|fetch]]. 
     </p>
   </section>
@@ -116,7 +111,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
     <p>The
       <code>fetchpriority</code> <a>enumerated attribute</a> may be used with resource-requesting elements including <{link}>,
-      <{img}>, <{script}> and <{iframe}>. This keyword hints to the browser the relative fetch priority
+      <{img}>, and <{script}>. This keyword hints to the browser the relative fetch priority
       a developer intends for a resource to have.</p>
 
     <ul>
@@ -185,13 +180,13 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
     <h3 id="html-integration">HTML Integration</h3>
     <em>This section will be removed once the [[HTML|HTML]] specification has been modified.</em>
-    <p>For the supported elements (<{img}>, <{link}>, <{script}> and <{iframe}>) the integration
+    <p>For the supported elements (<{img}>, <{link}>, and <{script}>) the integration
     with HTML is to add an <code data-x="">fetchpriority</code> attribute to the relevant element
     specification and pass the value through to the underlying fetch priority for the resource
     referenced by the given element.</p>
     <p>The fetchpriority value is plumbed through to the fetch for the referenced resource with
     no downstream impact on later behaviors of the given element (i.e. later fetches initiated by
-    a frame or script are not impacted nor is the scheduling of execution or prioritization of
+    a script are not impacted nor is the scheduling of execution or prioritization of
     tasks affected).</p>
 
     <ol>
@@ -321,35 +316,6 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
         <code data-x="concept-script-fetch-options-fetchpriority">fetchpriority</code>
       <li>We modify the [=List of elements=] to include the 
         <span data-x="attr-script-fetchpriority">fetchpriority</span> attribute on the <{script}>
-        element.
-    </ol>
-
-    <h4 id="iframe">iframe</h4>
-    <ol>
-      <li><p>We add to the <{iframe}> element content attributes:</p>
-        <p><code data-x="">fetchpriority</code> - FetchPriority for [=fetch|fetches=] initiated by the
-          element.
-        </p>
-      <li>We extend the <{iframe}> element DOM interface as follows:
-        <pre class="idl">
-        partial interface HTMLIFrameElement {
-            [CEReactions] attribute DOMString <span data-x="dom-iframe-fetchpriority">fetchPriority</span>;
-        };
-        </pre>
-      <li><p>We add to the <{iframe}> content attribute descriptions:</p>
-        <p>The <dfn element-attr for="iframe"><code data-x="attr-iframe-fetchpriority">fetchpriority
-          </code></dfn> attribute is a [=fetchpriority attribute=]. Its purpose is to set the
-          [=priority=] used when [=processing the iframe attributes=].</p>
-        <p>The <dfn attribute for="HTMLIFrameElement"><code
-          data-x="dom-iframe-fetchpriority">fetchPriority</code></dfn> IDL attribute must
-          <span>reflect</span> the <code data-x="attr-iframe-fetchpriority">fetchpriority</code>
-          content attribute, <span>limited to only known values</span>.</p>
-      <li><p>We modify step 5 (the resource creation step) of
-          [=shared attribute processing steps for iframe and frame elements=] to include:</p>
-        <p>...and whose <a spec=fetch for=request>priority</a> is the current state of element's
-          <code data-x="attr-iframe-fetchpriority">fetchpriority</code> content attribute</p>
-      <li>We modify the [=List of elements=] to include the 
-        <span data-x="attr-iframe-fetchpriority">fetchpriority</span> attribute on the <{iframe}>
         element.
     </ol>
 
@@ -548,7 +514,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
       <li>Signals relating the script execution order, script execution grouping, execution dependency, etc.</li>
 
-      <li>Signal the execution priority of <{script}> or <{iframe}> elements beyond the load of the initial resource.</li>
+      <li>Signal the execution priority of <{script}> elements beyond the load of the initial resource.</li>
     </ul>
   </section>
 

--- a/index.bs
+++ b/index.bs
@@ -68,7 +68,6 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 
 <body>
   <section>
-    <h2 id="summary">Summary</h2>
     <p>
       This specification describes a browser API enabling developers to signal the priority of each resource they need to download.
       It introduces the
@@ -78,7 +77,6 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
     </p>
   </section>
   <section id="sotd">
-    <h2 id="unofficial">Unofficial</h2>
     <p>
       This is an unofficial proposal.
     </p>


### PR DESCRIPTION
This removes references of iFrame support for the fetchpriority attribute.